### PR TITLE
Patched but in rails where it strips newlines from multiline strings in ...

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -52,3 +52,18 @@ TESTING     = (ENV["RAILS_ENV"] == 'test')
 
 MO = MushroomObserver::Application.config
 require File.expand_path("../consts.rb", __FILE__)
+
+# Patch bug in how rails sends multiline strings via "render text: string".
+module ActionDispatch
+  class Response
+    class Buffer
+      def each(&block)
+        if @buf.is_a?(String)
+          [@buf].each(&block)
+        else
+          @buf.each(&block)
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/observer_controller_test.rb
+++ b/test/controllers/observer_controller_test.rb
@@ -2520,7 +2520,7 @@ class ObserverControllerTest < FunctionalTestCase
       "Exported 1st column incorrect")
     fourth_row = rows[last_expected_index].chop
     assert_equal(
-      "10,2,mary,Mary Newbie,2010-07-22,,1,Fungi,,kingdom,0.0,2," \
+      "10,2,mary,Mary Newbie,2010-07-22,,1,Fungi,,Kingdom,0.0,2," \
         "USA,California,,Burbank," \
         "34.1622,-118.3521,,34.22,34.15,-118.29,-118.37,294,148,X,",
       fourth_row.iconv('utf-8'), "Exported 4th row incorrect"


### PR DESCRIPTION
...send_data(string) and render(:text => string).
