### PR TITLE
Delete problematic line in CodeClimate configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,4 +7,3 @@ exclude_paths:
 - app/assets/javascripts/jquery.js
 - app/assets/javascripts/jstz.js
 - app/assets/javascripts/lightbox.js
-- **.old.rb


### PR DESCRIPTION
- This line is obsolete (**.old.rb files have been deleted)
- More important, it may have prevented the Classic CodeClimate from running/completing.  At least in the new CodeClimate engines config files, lines which start with “**” must be wrapped in quotes.